### PR TITLE
Use checkout scm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
+#!groovy
 stage 'Dev'
 node {
-    git 'https://github.com/ndeloof/cddemo'
+    checkout scm
     sh "mvn clean package"
     dir('target') {stash name: 'war', includes: 'x.war'}
 }
@@ -15,13 +16,13 @@ node {
 parallel(
     smokeTests: {
         node {
-            git 'https://github.com/ndeloof/cddemo'
+            checkout scm
             sh "mvn test -f sometests -P smoke -Durl=http://localhost:8080/test"
         }
     }, 
     acceptanceTests: {
         node {
-            git 'https://github.com/ndeloof/cddemo'
+            checkout scm
             sh "mvn test -f sometests -P acceptance -Durl=http://localhost:8080/test"
         }
     }


### PR DESCRIPTION
If we are really in a `Jenkinsfile` loaded by `workflow-multibranch` (not currently the case [here](https://github.com/ndeloof/cddemo-demos/blob/125154dac11d92a4fd0213e45a469eb5a22b438f/jenkins-home/jobs/future/jobs/Jenkinsfile/config.xml#L7)) then you should use `checkout scm`.